### PR TITLE
fix associations and migrations

### DIFF
--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -1,4 +1,4 @@
 class Response < ApplicationRecord
   belongs_to :question
-  belongs_to :respondant, class_name: "User"
+  belongs_to :respondant, class_name: "User", optional: true
 end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,6 +1,6 @@
 class Survey < ApplicationRecord
   has_many :questions, inverse_of: :survey, dependent: :destroy
   has_many :responses, through: :questions
-  belongs_to :owner, class_name: "User"
+  belongs_to :owner, class_name: "User", foreign_key: "owner_id"
   accepts_nested_attributes_for :questions, allow_destroy: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
-  has_many :surveys
-  has_many :responses
+  has_many :surveys, foreign_key: :owner_id
+  has_many :responses, foreign_key: :responder_id
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20180920234928_create_surveys.rb
+++ b/db/migrate/20180920234928_create_surveys.rb
@@ -3,8 +3,8 @@ class CreateSurveys < ActiveRecord::Migration[5.2]
     create_table :surveys do |t|
       t.string :title
       t.text :description
-      t.references :owner, foreign_key: true
-      t.references :question, foreign_key: true
+      t.references :owner, index: true
+      t.references :question, index: true
 
       t.timestamps
     end

--- a/db/migrate/20180920235009_create_questions.rb
+++ b/db/migrate/20180920235009_create_questions.rb
@@ -4,7 +4,8 @@ class CreateQuestions < ActiveRecord::Migration[5.2]
       t.string :type
       t.text :content
       t.integer :order
-      t.references :survey, foreign_key: true
+      t.references :survey, index: true
+      t.references :response, index: true
 
       t.timestamps
     end

--- a/db/migrate/20180920235113_create_options.rb
+++ b/db/migrate/20180920235113_create_options.rb
@@ -3,7 +3,7 @@ class CreateOptions < ActiveRecord::Migration[5.2]
     create_table :options do |t|
       t.string :letter
       t.string :option
-      t.references :question, foreign_key: true
+      t.references :question, index: true
 
       t.timestamps
     end

--- a/db/migrate/20180921020431_devise_create_users.rb
+++ b/db/migrate/20180921020431_devise_create_users.rb
@@ -3,6 +3,8 @@
 class DeviseCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :users do |t|
+      t.references :survey, index: true
+      t.references :response, index: true
       ## Database authenticatable
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,8 +29,10 @@ ActiveRecord::Schema.define(version: 2018_09_21_020431) do
     t.text "content"
     t.integer "order"
     t.bigint "survey_id"
+    t.bigint "response_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["response_id"], name: "index_questions_on_response_id"
     t.index ["survey_id"], name: "index_questions_on_survey_id"
   end
 
@@ -49,12 +51,16 @@ ActiveRecord::Schema.define(version: 2018_09_21_020431) do
     t.string "title"
     t.text "description"
     t.bigint "owner_id"
+    t.bigint "question_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["owner_id"], name: "index_surveys_on_owner_id"
+    t.index ["question_id"], name: "index_surveys_on_question_id"
   end
 
   create_table "users", force: :cascade do |t|
+    t.bigint "survey_id"
+    t.bigint "response_id"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -64,8 +70,8 @@ ActiveRecord::Schema.define(version: 2018_09_21_020431) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["response_id"], name: "index_users_on_response_id"
+    t.index ["survey_id"], name: "index_users_on_survey_id"
   end
 
-  add_foreign_key "options", "questions"
-  add_foreign_key "questions", "surveys"
 end


### PR DESCRIPTION
was unable to access created surveys from the user mode due to lacking foreign_key. was also getting errors with foreign_key reference restrictions, so used index instead.